### PR TITLE
auto reconnect for serial and wifi

### DIFF
--- a/.idea/QtSettings.xml
+++ b/.idea/QtSettings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="QtSettings">
-    <option name="myCurrentProfile" value="Release" />
+    <option name="myCurrentProfile" value="Debug" />
     <option name="mySettingsPerProfile">
       <map>
         <entry key="Debug">

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,7 +38,7 @@ else()
 endif ()
 find_package(OpenCV CONFIG REQUIRED)
 find_package(CURL CONFIG REQUIRED)
-find_package(Qt6 COMPONENTS Core Gui Widgets Network WebSockets REQUIRED)
+find_package(Qt6 COMPONENTS Core Gui Widgets Network WebSockets SerialPort REQUIRED)
 
 IF(WIN32)
     set(IpSystemTypePath ip/win32)
@@ -137,7 +137,7 @@ target_include_directories(
 target_link_libraries(
     transfer
     PUBLIC
-    Qt6::Core Qt6::WebSockets  Qt6::Network
+    Qt6::Core Qt6::WebSockets  Qt6::Network Qt6::SerialPort
     ${OpenCV_LIBS}
     onnxruntime
     oscpack
@@ -167,9 +167,7 @@ target_include_directories(
 target_link_libraries(
     ui
     PUBLIC
-    Qt6::Core
-    Qt6::Gui
-    Qt6::Widgets
+    Qt6::Core Qt6::Gui Qt6::Widgets Qt6::SerialPort
     ${OpenCV_LIBS}
     onnxruntime
     oscpack
@@ -204,6 +202,7 @@ target_link_libraries(PaperTracker PRIVATE
     Qt6::Widgets
     Qt6::Network
     Qt6::WebSockets
+    Qt6::SerialPort
     onnxruntime
     oscpack
     ${LIBS}
@@ -254,7 +253,7 @@ if (WIN32 AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
                 "${QT_INSTALL_PATH}/plugins/platforms/qwindows${DEBUG_SUFFIX}.dll"
                 "$<TARGET_FILE_DIR:${PROJECT_NAME}>/plugins/platforms/")
     endif()
-    foreach(QT_LIB Core Gui Widgets Network Websockets)
+    foreach(QT_LIB Core Gui Widgets Network Websockets SerialPort)
         add_custom_command(TARGET ${PROJECT_NAME} POST_BUILD
                 COMMAND ${CMAKE_COMMAND} -E copy
                 "${QT_INSTALL_PATH}/bin/Qt6${QT_LIB}${DEBUG_SUFFIX}.dll"

--- a/transfer/include/image_downloader.hpp
+++ b/transfer/include/image_downloader.hpp
@@ -8,21 +8,17 @@
 #include <opencv2/core.hpp>
 #include <QWebSocket>
 #include <QObject>
-#include <QByteArray>
-#include <QImage>
 #include <QMutex>
 #include "logger.hpp"
 
 class ESP32VideoStream : public QObject {
-
-
 public:
     // 构造函数和析构函数
-    ESP32VideoStream(QObject *parent = nullptr);
-    ~ESP32VideoStream();
+    explicit ESP32VideoStream(QObject *parent = nullptr);
+    ~ESP32VideoStream() override;
 
     // 初始化视频流，设置ESP32的URL
-    bool init(const std::string& url);
+    bool init(const std::string& url = {});
 
     // 开始接收视频流
     bool start();
@@ -59,7 +55,7 @@ private:
     // 成员变量
     std::atomic<bool> isRunning;
     std::string currentStreamUrl;
-    QWebSocket webSocket;
+    QWebSocket* webSocket;
     mutable QMutex mutex;
     std::queue<cv::Mat> image_buffer_queue;
 };

--- a/transfer/include/serial.hpp
+++ b/transfer/include/serial.hpp
@@ -136,7 +136,7 @@ public:
 
     void start() const;
 
-    void stop() const;
+    void stop();
 
     void write_data(const std::string& data) const;
 

--- a/transfer/include/serial.hpp
+++ b/transfer/include/serial.hpp
@@ -7,6 +7,13 @@
 #include <thread>
 #include <condition_variable>
 #include <functional>
+#include <QMutexLocker>
+#include <QSerialPort>
+#include <QObject>
+#include <QSerialPort>
+#include <QWaitCondition>
+#include <QQueue>
+#include <QThread>
 #include "logger.hpp"
 
 enum SerialStatus
@@ -27,56 +34,133 @@ enum PacketType {
     PACKET_LIGHT_CONTROL = 6   // 补光灯控制
 };
 
-class SerialPortManager {
+class SerialReader : public QObject {
 public:
-    SerialPortManager();
-    ~SerialPortManager();
+    explicit SerialReader(QSerialPort* port, SerialStatus* status, QObject* parent = nullptr) : QObject(parent), serialPort(port), status(status) {}
     // 添加一个回调函数类型
     using DeviceStatusCallback = std::function<void(const std::string& ip, int brightness, int power, int version)>;
+    void setDeviceStatusCallback(DeviceStatusCallback callback) {
+        deviceStatusCallback = std::move(callback);
+    }
+public slots:
+    void onReadyRead() {
+        if (!serialPort)
+        {
+            *status = SerialStatus::FAILED;
+            return;
+        }
+        QByteArray data = serialPort->readAll();
+        if (data.isEmpty())
+        {
+            return;
+        }
+        auto receivedData = QString::fromLocal8Bit(data).toStdString();
+        processReceivedData(receivedData);
+    }
 
-    // 添加设置回调的方法
-    void setDeviceStatusCallback(DeviceStatusCallback callback);
+private:
+    // 解析接收的数据包
+    PacketType parsePacket(const std::string& packet) const;
+
+    // 处理接收到的数据
+    void processReceivedData(std::string& receivedData) const;
+
+    QSerialPort* serialPort;
+    SerialStatus* status;
+    // 添加回调函数成员
+    DeviceStatusCallback deviceStatusCallback;
+};
+
+class SerialWriter : public QObject {
+public:
+    explicit SerialWriter(QSerialPort* port, SerialStatus* status, QObject* parent = nullptr)
+        : QObject(parent), serialPort(port), stop(false), status(status) {}
+
+    void sendData(const QByteArray& data) {
+        QMutexLocker locker(&mutex);
+        writeQueue.enqueue(data);
+        cond.wakeOne();  // 唤醒写入线程
+    }
+
+    void stopWriting() {
+        QMutexLocker locker(&mutex);
+        stop = true;
+        cond.wakeOne();  // 唤醒线程确保它能够退出
+    }
+
+public slots:
+    void processWriteQueue() {
+        while (!stop) {
+            QByteArray data;
+            {
+                QMutexLocker locker(&mutex);
+                if (writeQueue.isEmpty()) {
+                    cond.wait(&mutex);  // 没数据时等待
+                    continue;
+                }
+                data = writeQueue.dequeue();
+            }
+
+            if (serialPort && serialPort->isOpen()) {
+                serialPort->write(data);
+                serialPort->flush();
+            } else
+            {
+                *status = SerialStatus::FAILED;
+            }
+            QThread::msleep(50);  // 控制写入频率，避免 CPU 过载
+        }
+    }
+private:
+    QSerialPort* serialPort;
+    QQueue<QByteArray> writeQueue;
+    QMutex mutex;
+    QWaitCondition cond;
+    bool stop;
+    SerialStatus* status;
+};
+
+
+class SerialPortManager : public QObject {
+public:
+    explicit SerialPortManager(QObject *parent = nullptr);
+    ~SerialPortManager() override;
+    using DeviceStatusCallback = std::function<void(const std::string& ip, int brightness, int power, int version)>;
+
+    void setDeviceStatusCallback(DeviceStatusCallback callback)
+    {
+        reader->setDeviceStatusCallback(callback);
+    }
 
     void init();
-    void start();
-    void stop();
-    void write_data(const std::string& data);
 
-    [[nodiscard]] SerialStatus status() const;
+    void start() const;
+
+    void stop() const;
+
+    void write_data(const std::string& data) const;
+
+    SerialStatus status() const;
 
     // 发送WiFi配置信息
-    static void sendWiFiConfig(HANDLE hSerial, const std::string& ssid, const std::string& pwd);
+    void sendWiFiConfig(const std::string& ssid, const std::string& pwd) const;
     
     // 发送补光灯控制命令
-    static void sendLightControl(HANDLE hSerial, int brightness);
+    void sendLightControl(int brightness) const;
+
+    void restartESP32(QWidget* window);
+
+    void flashESP32(QWidget* window);
 
     // 查找ESP32-S3设备串口
     std::string FindEsp32S3Port();
 private:
-
-    // 添加回调函数成员
-    DeviceStatusCallback deviceStatusCallback;
-    HANDLE hSerial;         // 串口句柄
-    bool running;           // 控制线程运行状态
-    
-    std::thread read_thread;       // 读取线程
-    std::thread write_thread;      // 写入线程
-    std::thread write_junk_thread; // 测试用的写线程
-
-    // 写入队列
-    std::queue<std::string> writeQueue;
-    std::mutex writeQueueMutex;
-    std::condition_variable writeQueueCV;
-
-    // 初始化串口
-    HANDLE initSerialPort(const wchar_t* portName);
-
-    // 解析接收的数据包
-    [[nodiscard]] PacketType parsePacket(const std::string& packet) const;
-    
-    // 处理接收到的数据
-    void processReceivedData(std::string& receivedData) const;
-    std::string currentPort = ""; // 默认端口
-
+    std::string currentPort; // 默认端口
+    QSerialPort* serialPort;
     SerialStatus m_status;
+
+    SerialReader* reader{};
+    SerialWriter* writer{};
+    QThread* readerThread{};
+    QThread* writerThread{};
 };

--- a/transfer/serial.cpp
+++ b/transfer/serial.cpp
@@ -219,8 +219,12 @@ void SerialPortManager::start() const
     writerThread->start();
 }
 
-void SerialPortManager::stop() const
+void SerialPortManager::stop()
 {
+    if (m_status == SerialStatus::CLOSED)
+    {
+        return ;
+    }
     if (reader)
     {
         readerThread->quit();
@@ -240,6 +244,7 @@ void SerialPortManager::stop() const
         serialPort->close();
         delete serialPort;
     }
+    m_status = SerialStatus::CLOSED;
 }
 
 // 处理接收到的数据


### PR DESCRIPTION
This pull request includes several changes to improve the handling of serial ports and WebSocket connections, as well as some general code clean-up and refactoring. The most important changes are grouped by theme and listed below:

### Serial Port and WebSocket Enhancements:
* Added `Qt6::SerialPort` to the list of required Qt6 components in `CMakeLists.txt` and updated the `target_link_libraries` sections to include `Qt6::SerialPort`. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL41-R41) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL140-R140) [[3]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL170-R170) [[4]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR205) [[5]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL257-R256)
* Introduced `RestartWorker`, a new QThread subclass in `main.cpp` to handle automatic reconnection of the serial port and WebSocket in case of disconnection.
* Modified `ESP32VideoStream` class in `transfer/image_downloader.cpp` to dynamically allocate `QWebSocket` and manage its lifecycle, ensuring proper initialization and cleanup. [[1]](diffhunk://#diff-2fd514f075d77a80e9845dc3552f45140fd1bbe1140f47e379b768cdc0ffebb1L25-R26) [[2]](diffhunk://#diff-2fd514f075d77a80e9845dc3552f45140fd1bbe1140f47e379b768cdc0ffebb1R72-R93) [[3]](diffhunk://#diff-2fd514f075d77a80e9845dc3552f45140fd1bbe1140f47e379b768cdc0ffebb1L103-R112) [[4]](diffhunk://#diff-2fd514f075d77a80e9845dc3552f45140fd1bbe1140f47e379b768cdc0ffebb1L135-R152)

### Code Refactoring:
* Removed the `restart_esp32` and `flash_esp32` functions from `main.cpp` and replaced their functionality with methods in `SerialPortManager`. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL35-L218) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL458-R328)
* Simplified the `start_image_download` function by removing the `PaperTrackMainWindow` parameter. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbR14-R25) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL502-L507) [[3]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL548-R412)

### Minor Fixes and Improvements:
* Corrected a typo in the `inference_image` function comment from "caculate" to "calculate".
* Changed the `fps` calculation to use `static_cast<double>` for improved accuracy in `main.cpp`. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL261-R77) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL320-R151)
* Removed an unused static variable `max_rate` from `update_ui` and `inference_image` functions. [[1]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL232-L233) [[2]](diffhunk://#diff-608d8de3fba954c50110b6d7386988f27295de845e9d7174e40095ba5efcf1bbL320-R151)

These changes collectively enhance the reliability and maintainability of the codebase, particularly in handling serial and WebSocket connections.